### PR TITLE
get blame result for correct line

### DIFF
--- a/src/com/SZZ/jiraAnalyser/git/Git.java
+++ b/src/com/SZZ/jiraAnalyser/git/Git.java
@@ -296,7 +296,7 @@ public class Git {
 		      blamer.setStartCommit(commitID);
 		      blamer.setFilePath(file);
 		      blame = blamer.call();}
-		      RevCommit commit = blame.getSourceCommit(lineNumber);
+		      RevCommit commit = blame.getSourceCommit(lineNumber - 1);
 		      return commit.getName();
 		} catch (Exception e) {
 			return null;


### PR DESCRIPTION
[The getSourceCommit method](http://archive.eclipse.org/jgit/docs/jgit-2.0.0.201206130900-r/apidocs/org/eclipse/jgit/blame/BlameResult.html#getSourceCommit(int)) takes 0 based line number as
an argument, but in OpenSZZ, a line number extracted from `git diff` result is passed
as an argument. It is incorrect because in `git diff` output line numbers start with 1.
Without a fix, for each line of a bug-fixing commit, OpenSZZ finds a commit that
made the last change in the next line instead of a commit that made the last change
in the current line.