### PR TITLE
continue files iteration even if some of them doen't have changed lines

### DIFF
--- a/src/com/SZZ/jiraAnalyser/entities/Link.java
+++ b/src/com/SZZ/jiraAnalyser/entities/Link.java
@@ -254,12 +254,12 @@ public class Link {
 			if (fi.filename.endsWith(".java")) {
 					String diff = git.getDiff(transaction.getId(), fi.filename, l);
 					if (diff == null)
-						break;
+						continue;
 					List<Integer> linesMinus = git.getLinesMinus(diff);
 					if (linesMinus == null)
-						return;
+						continue;
 					if (linesMinus.size() == 0)
-						return;
+						continue;
 					String previousCommit = git.getPreviousCommit(transaction.getId(), fi.filename,l);
 					if (previousCommit != null) {
 						Suspect s = getSuspect(previousCommit, git, fi.filename, linesMinus,l);
@@ -286,7 +286,7 @@ public class Link {
     		try{ 
     			String sha = git.getBlameAt(previous,fileName,i);
     			if (sha == null)
-    				break;
+    				continue;
     			RevCommit commit = git.getCommit(sha,l); 
     			long difference =(issue.getOpen()/1000) - (commit.getCommitTime()); 
     			if (difference > 0){ 


### PR DESCRIPTION
The process of iterating files of a bug-fixing commit finishes once one of the files does not have modified lines. This leads to the situations when bug-introducing commits are not found because files with modified lines followed files with added new lines only. 
Instead, file iteration should continue.