### PR TITLE
analyze not only .java files

### DIFF
--- a/src/com/SZZ/jiraAnalyser/entities/Link.java
+++ b/src/com/SZZ/jiraAnalyser/entities/Link.java
@@ -244,6 +244,12 @@ public class Link {
 		return this.semanticConfidence;
 	}
 
+	private static boolean isCodeFile(FileInfo file) {
+		if (!file.filename.contains(".")) return false;
+		List<String> extensionsToIgnore = Arrays.asList("txt","md");
+		return extensionsToIgnore.stream().noneMatch(extension -> file.filename.endsWith("." + extension));
+	}
+
 	/**
 	 * For each modified file it calculates the suspect
 	 * 
@@ -251,7 +257,7 @@ public class Link {
 	 */
 	public void calculateSuspects(Git git, PrintWriter l) {
 		for (FileInfo fi : transaction.getFiles()) {
-			if (fi.filename.endsWith(".java")) {
+			if (isCodeFile(fi)) {
 					String diff = git.getDiff(transaction.getId(), fi.filename, l);
 					if (diff == null)
 						break;


### PR DESCRIPTION
Even Java repositories contain also files of other types (for example, .xml and
.sh) and bugs can be introduced with changes in such files. OpenSZZ
should analyze changes in all non-binary files except .txt and .md files (changes
in text and markdown files most likely do not affect software’s behaviour). This
will also make it possible to use OpenSZZ with other non-Java repositories.