### PR TITLE
instead of saving 1K issues per file, save issues with ID within a thousand per file

### DIFF
--- a/src/com/SZZ/jiraAnalyser/entities/Link.java
+++ b/src/com/SZZ/jiraAnalyser/entities/Link.java
@@ -206,7 +206,7 @@ public class Link {
 					}
 					
 					try{
-						Resolution.valueOf(s[2].toUpperCase().replace(" ", "").replace("'", ""));
+						resolution = Resolution.valueOf(s[2].toUpperCase().replace(" ", "").replace("'", ""));
 					}
 					catch(Exception e){
 						 resolution = Resolution.NONE;

--- a/src/com/SZZ/jiraAnalyser/git/JiraRetriever.java
+++ b/src/com/SZZ/jiraAnalyser/git/JiraRetriever.java
@@ -73,6 +73,10 @@ public class JiraRetriever {
 		return doc;
 	}
 
+	private int getIssueIdFromKey(String key) {
+		return Integer.parseInt(key.replaceFirst(".*?(\\d+).*", "$1"));
+	}
+
 	private int getTotalNumberIssues() {
 		String tempQuery = "?jqlQuery=project+%3D+{0}+ORDER+BY+key+DESC&tempMax=1";
 		tempQuery = tempQuery.replace("{0}", projectName);
@@ -85,8 +89,7 @@ public class JiraRetriever {
 			for (int p = 0; p < node.getChildNodes().getLength(); p++) {
 				if (node.getChildNodes().item(p).getNodeName().equals("key")) {
 					String key = (node.getChildNodes().item(p).getTextContent());
-					key = key.replaceFirst(".*?(\\d+).*", "$1");
-					return Integer.parseInt(key);
+					return getIssueIdFromKey(key);
 				}
 			}
 		} catch (Exception e) {
@@ -98,6 +101,7 @@ public class JiraRetriever {
 	public void printIssues() {
 		int page = 0;
 		int totalePages = (int) Math.ceil(((double) getTotalNumberIssues() / 1000));
+		int numberOfIssues = 0;
 		String fileName = projectName + "_" + page + ".csv";
 		File file = new File( fileName);
 		System.out.println("Jira issues saved in "+fileName);
@@ -116,7 +120,7 @@ public class JiraRetriever {
 		while (true) {
 			String tempQuery = "?jqlQuery=project+%3D+{0}+ORDER+BY+key+ASC&tempMax=1000&pager/start={1}";
 			tempQuery = tempQuery.replace("{0}", projectName);
-			tempQuery = tempQuery.replace("{1}", ((page) * 1000) + "");
+			tempQuery = tempQuery.replace("{1}", numberOfIssues + 1 + "");
 			if (totalePages >= (page + 1))
 				System.out.println("Download Jira issues. Page: " + (page + 1) + "/" + totalePages);
 			try {
@@ -140,7 +144,7 @@ public class JiraRetriever {
 					e1.printStackTrace();
 				}
 				printHeader(pw);
-				printIssuesOfPage(d, pw);
+				numberOfIssues += printIssuesOfPage(d, pw, page);
 				pw.close();
 				page++;
 			} catch (Exception e) {
@@ -166,13 +170,15 @@ public class JiraRetriever {
 	/**
 	 * 
 	 * @param doc
-	 * @param nodeName
+	 * @param pw
+	 * @param pageNumber
 	 * @return
 	 */
-	private void printIssuesOfPage(Document doc, PrintWriter pw) {
+	private int printIssuesOfPage(Document doc, PrintWriter pw, int pageNumber) {
 		NodeList descNodes = doc.getElementsByTagName("item");
 		SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
-		for (int i = 0; i < descNodes.getLength(); i++) {
+		int numberOfIssues = 0;
+		loop: for (int i = 0; i < descNodes.getLength(); i++) {
 			Node node = descNodes.item(i);
 			String issueKey = "";
 			String priority = "";
@@ -196,7 +202,9 @@ public class JiraRetriever {
 					resolution = children.item(p).getTextContent();
 					break;
 				case "key":
-					issueKey = children.item(p).getTextContent();
+					String key = children.item(p).getTextContent();
+					if (getIssueIdFromKey(key) >= (pageNumber + 1) * 1000) break loop;
+					issueKey = key;
 					break;
 				case "created":
 					String createdDate = children.item(p).getTextContent();
@@ -256,8 +264,8 @@ public class JiraRetriever {
 						.replace("\r", "").replace("\t", "") + ";";
 			}
 			pw.println(toPrint);
-
+			numberOfIssues++;
 		}
-
+		return numberOfIssues;
 	}
 }


### PR DESCRIPTION
OpenSZZ stores issues in .csv files with maximum 1000 issues in each. This way, a file <project_key>_0.csv has issues with ID from 1 to 999, file <project_key>_1.csv has issues with ID from 1000 to 1999, and so on.
To fetch certain portion of issues from Jira API, OpenSZZ uses the next parameters in JQL query:
– project=<project_key> ORDER BY key ASC
– tempMax=1000
– pager/start=<page_number*1000>
With <project_key> = OOZIE and <page_number> = 2 the query is interpreted as follows: from all issues of OOZIE project sorted by issue key in ascending order return 1000 issues starting from 2000th result.
On the step of linking commits to issues, OpenSZZ extracts issue IDs from commit messages. Then OpenSZZ searches the issues with IDs equal to the extracted ones not in all files with fetched issues, but only in files that are supposed to contain them. Therefore, OpenSZZ will search an issue OOZIE-2222 in OOZIE_2.csv.

The process works correctly as long as issues are not deleted in the Jira project. When some issues are deleted from a Jira project, it is possible that some other issues will not be found by OpenSZZ because they are stored in another file and not in the file where they are supposed to be. For example, if any issue with the ID
between 1000 and 2000 is deleted, then the query used to return 1000 results after 1000 results returns issues with IDs from 1000 to 2001. Thus, the issue with the ID 2000 will be stored in the file <project_key>_1.csv and will not be found in <project_key>_2.csv. Hence, even if a commit that references the issue with ID 2000 is a bug-fixing commit, it will not be considered bug-fixing because issues linked in the commit message will not be found.